### PR TITLE
Bug Fix: Do Not Set -1 to _messageCount which type is NSUInteger.

### DIFF
--- a/SensorsAnalyticsSDK/MessageQueueBySqlite.m
+++ b/SensorsAnalyticsSDK/MessageQueueBySqlite.m
@@ -174,9 +174,9 @@
     return _messageCount;
 }
 
-- (NSInteger) sqliteCount {
+- (NSUInteger) sqliteCount {
     NSString* query = @"select count(*) from dataCache";
-    NSInteger count = -1;
+    NSUInteger count = 0;
     sqlite3_stmt* statement = [self dbCacheStmt:query];
     if(statement) {
         while (sqlite3_step(statement) == SQLITE_ROW) {


### PR DESCRIPTION
Bug Fix: Do Not Set -1 to _messageCount which type is NSUInteger. This will cause the old event to be deleted in the next launches.